### PR TITLE
Change sub-juntendoAchieva to juntendoAchieva

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -1,5 +1,5 @@
 csa_gm:
-- sub-juntendoAchieva  # repositionning (https://github.com/spine-generic/data-single-subject/issues/8)
+- juntendoAchieva  # repositionning (https://github.com/spine-generic/data-single-subject/issues/8)
 
 dti_fa:
 - perform  # strong aliasing artifact (https://github.com/spine-generic/data-single-subject/issues/10)


### PR DESCRIPTION
Change sub-juntendoAchieva to juntendoAchieva in `exclude.yml` file in order to display the site in the figures.

Mentioned in https://github.com/spine-generic/data-single-subject/issues/15#issuecomment-685717664